### PR TITLE
fix: empty text crash

### DIFF
--- a/ios/RNUITextViewShadow.swift
+++ b/ios/RNUITextViewShadow.swift
@@ -155,7 +155,7 @@ class RNUITextViewShadow: RCTShadowView {
     let maxSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(MAXFLOAT))
     let textSize = self.attributedText.boundingRect(with: maxSize, options: .usesLineFragmentOrigin, context: nil)
 
-    var totalLines = Int(ceil(textSize.height / self.lineHeight))
+    var totalLines = self.lineHeight == 0.0 ? 0 : Int(ceil(textSize.height / self.lineHeight))
 
     if self.numberOfLines != 0, totalLines > self.numberOfLines {
       totalLines = self.numberOfLines


### PR DESCRIPTION
fixes #3 

This fixes the crash when the content of UITextView is empty. The behaviour is not 100% consistent with react native's `Text` component. To be specific:
```tsx
<Text>test1</Text>
<Text></Text>
<Text>test2</Text>
```
renders as follows:
<img width="141" alt="Screenshot 2024-03-31 at 16 20 21" src="https://github.com/bluesky-social/react-native-uitextview/assets/34612663/d0455065-c02e-42ac-bc2b-24fedda9ffa9">

And now with this library:
```tsx
<UITextView selectable uiTextView>test1</UITextView>
<UITextView selectable uiTextView></UITextView>
<UITextView selectable uiTextView>test2</UITextView>
```

renders as follows:
<img width="115" alt="Screenshot 2024-03-31 at 16 21 33" src="https://github.com/bluesky-social/react-native-uitextview/assets/34612663/1d68f80d-2282-4af7-a9ec-84fb3a0f1078">

If someone would know what I should add to make the behaviour consistent, that would of course be better and I can update the PR. But for now this at least prevents the crash.  