### PR TITLE
chore: remove flipper from example podfile

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -17,7 +17,7 @@ prepare_react_native_project!
 #   dependencies: {
 #     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
 # ```
-flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+flipper_config = FlipperConfiguration.disabled
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - boost (1.83.0)
-  - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.5)
   - FBReactNativeSpec (0.73.5):
@@ -10,69 +9,12 @@ PODS:
     - React-Core (= 0.73.5)
     - React-jsi (= 0.73.5)
     - ReactCommon/turbomodule/core (= 0.73.5)
-  - Flipper (0.201.0):
-    - Flipper-Folly (~> 2.6)
-  - Flipper-Boost-iOSX (1.76.0.1.11)
-  - Flipper-DoubleConversion (3.2.0.1)
-  - Flipper-Fmt (7.1.7)
-  - Flipper-Folly (2.6.10):
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt (= 7.1.7)
-    - Flipper-Glog
-    - libevent (~> 2.1.12)
-    - OpenSSL-Universal (= 1.1.1100)
-  - Flipper-Glog (0.5.0.5)
-  - Flipper-PeerTalk (0.0.4)
-  - FlipperKit (0.201.0):
-    - FlipperKit/Core (= 0.201.0)
-  - FlipperKit/Core (0.201.0):
-    - Flipper (~> 0.201.0)
-    - FlipperKit/CppBridge
-    - FlipperKit/FBCxxFollyDynamicConvert
-    - FlipperKit/FBDefines
-    - FlipperKit/FKPortForwarding
-    - SocketRocket (~> 0.6.0)
-  - FlipperKit/CppBridge (0.201.0):
-    - Flipper (~> 0.201.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.201.0):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit/FBDefines (0.201.0)
-  - FlipperKit/FKPortForwarding (0.201.0):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.201.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.201.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.201.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-  - FlipperKit/FlipperKitLayoutPlugin (0.201.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - FlipperKit/FlipperKitLayoutIOSDescriptors
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.201.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.201.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.201.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.201.0):
-    - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.201.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
   - hermes-engine (0.73.5):
     - hermes-engine/Pre-built (= 0.73.5)
   - hermes-engine/Pre-built (0.73.5)
   - libevent (2.1.12)
-  - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2022.05.16.00):
     - boost
     - DoubleConversion
@@ -944,7 +886,7 @@ PODS:
   - React-Mapbuffer (0.73.5):
     - glog
     - React-debug
-  - react-native-uitextview (0.1.0):
+  - react-native-uitextview (1.1.5):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1123,30 +1065,9 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - Flipper (= 0.201.0)
-  - Flipper-Boost-iOSX (= 1.76.0.1.11)
-  - Flipper-DoubleConversion (= 3.2.0.1)
-  - Flipper-Fmt (= 7.1.7)
-  - Flipper-Folly (= 2.6.10)
-  - Flipper-Glog (= 0.5.0.5)
-  - Flipper-PeerTalk (= 0.0.4)
-  - FlipperKit (= 0.201.0)
-  - FlipperKit/Core (= 0.201.0)
-  - FlipperKit/CppBridge (= 0.201.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.201.0)
-  - FlipperKit/FBDefines (= 0.201.0)
-  - FlipperKit/FKPortForwarding (= 0.201.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.201.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.201.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.201.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.201.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.201.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.201.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.201.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
-  - OpenSSL-Universal (= 1.1.1100)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -1155,7 +1076,6 @@ DEPENDENCIES:
   - React-callinvoker (from `../node_modules/react-native/ReactCommon/callinvoker`)
   - React-Codegen (from `build/generated/ios`)
   - React-Core (from `../node_modules/react-native/`)
-  - React-Core/DevSupport (from `../node_modules/react-native/`)
   - React-Core/RCTWebSocket (from `../node_modules/react-native/`)
   - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
@@ -1196,18 +1116,8 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - CocoaAsyncSocket
-    - Flipper
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt
-    - Flipper-Folly
-    - Flipper-Glog
-    - Flipper-PeerTalk
-    - FlipperKit
     - fmt
     - libevent
-    - OpenSSL-Universal
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -1313,23 +1223,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
-  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 56e0e498dbb513b96c40bac6284729ba4e62672d
   FBReactNativeSpec: 146c741a3f40361f6bc13a4ba284678cbedb5881
-  Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
-  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
-  Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
-  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
-  Flipper-Folly: 584845625005ff068a6ebf41f857f468decd26b3
-  Flipper-Glog: 70c50ce58ddaf67dc35180db05f191692570f446
-  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  FlipperKit: 37525a5d056ef9b93d1578e04bc3ea1de940094f
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 1d1835b2cc54c381909d94d1b3c8e0a2f1a94a0e
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 2544c0f1081a5fa12e108bb8cb40e5f4581ccd87
   RCTTypeSafety: 50efabe2b115c11ed03fbf3fd79e2f163ddb5d7c
@@ -1351,7 +1251,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 32db5e364bcae8fca8cdf8891830636275add0c5
   React-logger: 0331362115f0f5b392bd7ed14636d1a3ea612479
   React-Mapbuffer: 7c35cd53a22d0be04d3f26f7881c7fb7dd230216
-  react-native-uitextview: 7d657de52255f7d52858137b8740a534cbee4b22
+  react-native-uitextview: 074935787667522fdde4625c7e57eb341270f892
   React-nativeconfig: 1166714a4f7ea57a0df5c2cb44fbc70f98d580f9
   React-NativeModulesApple: 726664e9829eb5eed8170241000e46ead269a05f
   React-perflogger: 0dd9f1725d55f8264b81efadd373fe1d9cca7dc2
@@ -1375,6 +1275,6 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 9e6a04eacbd94f97d94577017e9f23b3ab41cf6c
 
-PODFILE CHECKSUM: 52245834cbd8d4e1cf51b5fc8cbc8db17c7d2969
+PODFILE CHECKSUM: aa6cc99bfbc8a8e2372553471e71dd573afa91de
 
 COCOAPODS: 1.15.2

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -535,6 +535,19 @@ export default function App() {
               Press me Press me Press me Press me Press me Press me Press me
             </Text>
           </View>
+
+          <RNText style={styles.header}>Empty String</RNText>
+
+          <View>
+            <RNText style={styles.subheader}>Base</RNText>
+            {/* eslint-disable-next-line react/self-closing-comp */}
+            <RNText style={styles.text}></RNText>
+          </View>
+          <View>
+            <RNText style={styles.subheader}>UITextView</RNText>
+            {/* eslint-disable-next-line react/self-closing-comp */}
+            <Text style={styles.text} selectable uiTextView></Text>
+          </View>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/ios/RNUITextViewShadow.swift
+++ b/ios/RNUITextViewShadow.swift
@@ -8,7 +8,7 @@ class RNUITextViewShadow: RCTShadowView {
     }
   }
   @objc var allowsFontScaling: Bool = true
-  
+
   var attributedText: NSAttributedString = NSAttributedString()
   var frameSize: CGSize = CGSize()
 
@@ -87,24 +87,24 @@ class RNUITextViewShadow: RCTShadowView {
       guard let child = child as? RNUITextViewChildShadow else {
         return
       }
-      
+
       let scaledFontSize = self.allowsFontScaling ?
         UIFontMetrics.default.scaledValue(for: child.fontSize) : child.fontSize
-      let font = self.getFont(size: scaledFontSize, child: child)
+      let font = self.getFont(child)
 
       // Set some generic attributes that don't need ranges
       var attributes: [NSAttributedString.Key:Any] = [
         .font: font,
         .foregroundColor: child.color,
       ]
-      
+
       if child.textDecorationLine == .underline ||
          child.textDecorationLine == .underlineStrikethrough
       {
         attributes[.underlineStyle] = child.getTextDecorationStyle()
         attributes[.underlineColor] = child.getTextDecorationColor()
       }
-      
+
       if child.textDecorationLine == .strikethrough ||
          child.textDecorationLine == .underlineStrikethrough
       {
@@ -131,7 +131,7 @@ class RNUITextViewShadow: RCTShadowView {
           value: paragraphStyle,
           range: NSMakeRange(0, string.length)
         )
-        
+
         // To calcualte the size of the text without creating a new UILabel or UITextView, we have
         // to store this line height for later.
         self.lineHeight = child.lineHeight
@@ -154,7 +154,7 @@ class RNUITextViewShadow: RCTShadowView {
   func getNeededSize(maxWidth: Float) -> YGSize {
     let maxSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(MAXFLOAT))
     let textSize = self.attributedText.boundingRect(with: maxSize, options: .usesLineFragmentOrigin, context: nil)
-    
+
     var totalLines: Int = 0
     if self.lineHeight == 0 {
       totalLines = Int(ceil(textSize.height))
@@ -169,14 +169,20 @@ class RNUITextViewShadow: RCTShadowView {
     self.frameSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(CGFloat(totalLines) * self.lineHeight))
     return YGSize(width: Float(self.frameSize.width), height: Float(self.frameSize.height))
   }
-  
-  func getFont(size: CGFloat, child: RNUITextViewChildShadow) -> UIFont {
-    let font = UIFont.systemFont(ofSize: size, weight: child.getFontWeight())
-    
+
+  func getFont(_ child: RNUITextViewChildShadow?) -> UIFont {
+    guard let child = child else {
+      return UIFont.systemFont(ofSize: 16)
+    }
+
+    let scaledFontSize = self.allowsFontScaling ?
+      UIFontMetrics.default.scaledValue(for: child.fontSize) : child.fontSize
+    let font = UIFont.systemFont(ofSize: scaledFontSize, weight: child.getFontWeight())
+
     if child.fontStyle == "italic" {
       return font.italics()
     }
-    
+
     return font
   }
 }
@@ -191,7 +197,7 @@ extension UIFont {
       // the given traits couldn't be applied, return self
       return self
     }
-        
+
     // return a new font with the created font descriptor
     return UIFont(descriptor: fd, size: pointSize)
   }

--- a/ios/RNUITextViewShadow.swift
+++ b/ios/RNUITextViewShadow.swift
@@ -154,8 +154,13 @@ class RNUITextViewShadow: RCTShadowView {
   func getNeededSize(maxWidth: Float) -> YGSize {
     let maxSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(MAXFLOAT))
     let textSize = self.attributedText.boundingRect(with: maxSize, options: .usesLineFragmentOrigin, context: nil)
-
-    var totalLines = Int(ceil(textSize.height / self.lineHeight))
+    
+    var totalLines: Int = 0
+    if self.lineHeight == 0 {
+      totalLines = Int(ceil(textSize.height))
+    } else {
+      totalLines = Int(ceil(textSize.height / self.lineHeight))
+    }
 
     if self.numberOfLines != 0, totalLines > self.numberOfLines {
       totalLines = self.numberOfLines


### PR DESCRIPTION
Fixes crash whenever a `UITextView` has no children. Does not fix the fact that there is no default line height (or view height) which will be handled separately.