### PR TITLE
fix: map textDecorationStyle 'double' to Double, not Dotted

### DIFF
--- a/ios/RNUITextViewShadowNode.cpp
+++ b/ios/RNUITextViewShadowNode.cpp
@@ -96,7 +96,7 @@ Size RNUITextViewShadowNode::measureContent(
           textAttributes.textDecorationStyle = TextDecorationStyle::Dotted;
         } else if (props.textDecorationStyle == RNUITextViewChildTextDecorationStyle::Dashed) {
           textAttributes.textDecorationStyle = TextDecorationStyle::Dashed;
-        } else if (props.textDecorationStyle == RNUITextViewChildTextDecorationStyle::Dotted) {
+        } else if (props.textDecorationStyle == RNUITextViewChildTextDecorationStyle::Double) {
           textAttributes.textDecorationStyle = TextDecorationStyle::Double;
         }
         


### PR DESCRIPTION
## Summary

Spotted during a code-review pass.

`RNUITextViewShadowNode.cpp:99` checks `RNUITextViewChildTextDecorationStyle::Dotted` for the **second** time, so the branch that was supposed to set `TextDecorationStyle::Double` is unreachable. Result: \`textDecorationStyle: 'double'\` silently doesn't render as a double underline — it falls through to whatever the default is.

One-character fix.

## Test plan

- [ ] Render \`<UITextView selectable uiTextView style={{textDecorationLine: 'underline', textDecorationStyle: 'double'}}>\` and verify it renders as a double underline.
- [ ] Verify \`solid\`, \`dotted\`, \`dashed\` continue to render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)