### PR TITLE
fix: map fontWeight '500' string and 'medium' to medium

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -44,6 +44,8 @@ function fontWeightToNativeProp(
     case 'regular':
       return 'normal'
     case 500:
+    case '500':
+    case 'medium':
       return 'medium'
     case 600:
     case '600':


### PR DESCRIPTION
## Summary

Spotted during a code-review pass.

\`util.ts:46\` had \`case 500: return 'medium'\` for the numeric form, but the matching \`'500'\` string and the \`'medium'\` string literal — both valid \`fontWeight\` values in RN's \`TextStyle\` — were missing from the switch. They silently fell through to the default \`'normal'\` branch, so the native path rendered them as regular weight while the RN \`<Text>\` fallback rendered them as medium.

Every other weight pairs the number and string forms (\`100\`/\`'100'\`, \`200\`/\`'200'\`, …); this is just the missing pair.

## Test plan

- [ ] \`<UITextView selectable uiTextView style={{fontWeight: '500'}}>\` renders as medium.
- [ ] \`<UITextView selectable uiTextView style={{fontWeight: 'medium'}}>\` renders as medium.
- [ ] \`<UITextView selectable uiTextView style={{fontWeight: 500}}>\` (already worked) still renders as medium.
- [ ] Other weights unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)