### PR TITLE
Fix native text interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ block of text.
 > work the same as `2.x` and higher.
 
 > [!NOTE]
-> Version 2.0.0 of `@bsky.app/react-native-uitextview` is tested against and used in production with React Nave 0.79. No other versions
-> are officially supported. As there have been a number of changes to the text layout engine in the new architecture, things
-> may be broken if you are not using this version of React Native with this package. Generally, these problems are inside of
-> `RNUITextViewShadowNode.cpp`.
+> Version 2.4.0 of `@bsky.app/react-native-uitextview` is tested against React Native 0.86 and supports React Native 0.81.5 and newer.
+> React Native's new-architecture text layout APIs can change between releases; compatibility issues are most likely to arise
+> in `RNUITextViewShadowNode.cpp`.
 
 ```sh
 yarn add @bsky.app/react-native-uitextview

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -647,6 +647,58 @@ export default function App() {
             </Text>
           </View>
 
+          <View>
+            <RNText style={styles.subheader}>
+              UITextView, Bluesky emoji child shape
+            </RNText>
+            <RNText style={styles.fixtureLabel}>
+              Control (emoji remains in the string):
+            </RNText>
+            <Text style={[styles.text, styles.flexOne]} selectable uiTextView>
+              {'✅ '}
+              <Text
+                style={[styles.text, styles.coloredBlue, styles.underlined]}
+                onPress={() => onPress(4)}>
+                @thebulletin.org
+              </Text>
+              {' has been verified by '}
+              <Text
+                style={[styles.text, styles.coloredBlue, styles.underlined]}
+                onPress={() => onPress(5)}>
+                @bsky.app
+              </Text>
+              {'.'}
+            </Text>
+            <RNText style={styles.fixtureLabel}>
+              Bluesky shape (nested emoji and empty-string fragments):
+            </RNText>
+            <Text style={[styles.text, styles.flexOne]} selectable uiTextView>
+              {[
+                [
+                  '',
+                  <Text key="emoji" style={[styles.text, styles.systemFont]}>
+                    ✅
+                  </Text>,
+                  ' ',
+                ],
+                <Text
+                  key="first-mention"
+                  style={[styles.text, styles.coloredBlue, styles.underlined]}
+                  onPress={() => onPress(6)}>
+                  @thebulletin.org
+                </Text>,
+                ' has been verified by ',
+                <Text
+                  key="second-mention"
+                  style={[styles.text, styles.coloredBlue, styles.underlined]}
+                  onPress={() => onPress(7)}>
+                  @bsky.app
+                </Text>,
+                '.',
+              ]}
+            </Text>
+          </View>
+
           <RNText style={styles.header}>onTextLayout</RNText>
           <View>
             <RNText style={styles.subheader}>Base. Press to change</RNText>
@@ -839,6 +891,12 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 18,
+  },
+  flexOne: {
+    flex: 1,
+  },
+  systemFont: {
+    fontFamily: 'System',
   },
   coloredBlue: {
     color: 'blue',

--- a/ios/RNUITextView.mm
+++ b/ios/RNUITextView.mm
@@ -12,6 +12,20 @@
 
 using namespace facebook::react;
 
+static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsizeMode ellipsizeMode)
+{
+  switch (ellipsizeMode) {
+    case RNUITextViewEllipsizeMode::Clip:
+      return NSLineBreakByClipping;
+    case RNUITextViewEllipsizeMode::Head:
+      return NSLineBreakByTruncatingHead;
+    case RNUITextViewEllipsizeMode::Tail:
+      return NSLineBreakByTruncatingTail;
+    case RNUITextViewEllipsizeMode::Middle:
+      return NSLineBreakByTruncatingMiddle;
+  }
+}
+
 @interface RNUITextView () <RCTRNUITextViewViewProtocol, UIGestureRecognizerDelegate, UITextViewDelegate>
 
 @end
@@ -42,8 +56,13 @@ using namespace facebook::react;
     _textView = [[UITextView alloc] init];
     _textView.scrollEnabled = false;
     _textView.editable = false;
+    _textView.selectable = false;
     _textView.textContainerInset = UIEdgeInsetsZero;
     _textView.textContainer.lineFragmentPadding = 0;
+    // Keep UIKit's initial state in sync with the Codegen prop default. Since
+    // both oldProps and newProps default to `tail`, updateProps will not apply
+    // this value on the first render.
+    _textView.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
     _textView.delegate = self;
     // Must match RCTTextLayoutManager, which measures with usesFontLeading = NO.
     _textView.layoutManager.usesFontLeading = NO;
@@ -147,7 +166,7 @@ using namespace facebook::react;
 
   __block std::vector<std::string> lines;
   const int maxLines = props.numberOfLines;
-  [_textView.layoutManager enumerateLineFragmentsForGlyphRange:NSMakeRange(0, convertedAttrString.string.length) usingBlock:^(CGRect rect,
+  [_textView.layoutManager enumerateLineFragmentsForGlyphRange:NSMakeRange(0, _textView.layoutManager.numberOfGlyphs) usingBlock:^(CGRect rect,
                                                                                               CGRect usedRect,
                                                                                               NSTextContainer * _Nonnull textContainer,
                                                                                               NSRange glyphRange,
@@ -188,15 +207,8 @@ using namespace facebook::react;
   }
 
   if (oldViewProps.ellipsizeMode != newViewProps.ellipsizeMode) {
-    if (newViewProps.ellipsizeMode == RNUITextViewEllipsizeMode::Head) {
-      _textView.textContainer.lineBreakMode = NSLineBreakMode::NSLineBreakByTruncatingHead;
-    } else if (newViewProps.ellipsizeMode == RNUITextViewEllipsizeMode::Middle) {
-      _textView.textContainer.lineBreakMode = NSLineBreakMode::NSLineBreakByTruncatingMiddle;
-    } else if (newViewProps.ellipsizeMode == RNUITextViewEllipsizeMode::Tail) {
-      _textView.textContainer.lineBreakMode = NSLineBreakMode::NSLineBreakByTruncatingTail;
-    } else if (newViewProps.ellipsizeMode == RNUITextViewEllipsizeMode::Clip) {
-      _textView.textContainer.lineBreakMode = NSLineBreakMode::NSLineBreakByClipping;
-    }
+    _textView.textContainer.lineBreakMode =
+        RCTNSLineBreakModeFromEllipsizeMode(newViewProps.ellipsizeMode);
   }
   
 
@@ -258,49 +270,68 @@ using namespace facebook::react;
   return [sender locationInView:_textView];
 }
 
-- (RNUITextViewChild*)getTouchChild:(CGPoint)location
+- (std::shared_ptr<const RNUITextViewChildEventEmitter>)getTouchEventEmitter:(CGPoint)location
 {
-  const auto charIndex = [_textView.layoutManager characterIndexForPoint:location
-                                                         inTextContainer:_textView.textContainer
-                                fractionOfDistanceBetweenInsertionPoints:nil
-  ];
+  CGFloat fraction;
+  const auto characterIndex = [_textView.layoutManager characterIndexForPoint:location
+                                                               inTextContainer:_textView.textContainer
+                                      fractionOfDistanceBetweenInsertionPoints:&fraction];
 
-  int currIndex = -1;
-  for (UIView* child in self.subviews) {
-    if (![child isKindOfClass:[RNUITextViewChild class]]) {
-      continue;
-    }
-
-    RNUITextViewChild* textChild = (RNUITextViewChild*)child;
-
-    // This is UTF16 code units!!
-    currIndex += textChild.text.length;
-
-    if (charIndex <= currIndex) {
-      return textChild;
-    }
+  const auto textLength = _textView.attributedText.length;
+  if (textLength == 0 || characterIndex == NSNotFound || characterIndex >= textLength) {
+    return nullptr;
   }
 
-  return nil;
+  const auto lastCharacterRange =
+      [_textView.attributedText.string rangeOfComposedCharacterSequenceAtIndex:textLength - 1];
+  if ((characterIndex == 0 && fraction <= 0) ||
+      (characterIndex >= lastCharacterRange.location && fraction >= 1)) {
+    return nullptr;
+  }
+
+  const auto glyphIndex = [_textView.layoutManager glyphIndexForCharacterAtIndex:characterIndex];
+  const auto lineUsedRect = [_textView.layoutManager lineFragmentUsedRectForGlyphAtIndex:glyphIndex
+                                                                           effectiveRange:nullptr];
+  const auto textContainerLocation = CGPointMake(
+      location.x - _textView.textContainerInset.left,
+      location.y - _textView.textContainerInset.top);
+  if (!CGRectContainsPoint(lineUsedRect, textContainerLocation)) {
+    return nullptr;
+  }
+
+  NSData *eventEmitterWrapper =
+      (NSData *)[_textView.attributedText attribute:RCTAttributedStringEventEmitterKey
+                                           atIndex:characterIndex
+                                    effectiveRange:nullptr];
+  const auto eventEmitter = RCTUnwrapEventEmitter(eventEmitterWrapper);
+  return std::dynamic_pointer_cast<const RNUITextViewChildEventEmitter>(eventEmitter);
 }
 
 - (void)handlePressIfNecessary:(UITapGestureRecognizer*)sender
 {
   const auto location = [self getLocationOfPress:sender];
-  const auto child = [self getTouchChild:location];
+  const auto eventEmitter = [self getTouchEventEmitter:location];
 
-  if (child) {
-    [child onPress];
+  if (eventEmitter) {
+    const auto eventTarget = eventEmitter->getEventTarget();
+    const auto target = eventTarget ? eventTarget->getTag() : 0;
+    eventEmitter->onPress(RNUITextViewChildEventEmitter::OnPress{target});
   }
 }
 
 - (void)handleLongPressIfNecessary:(UILongPressGestureRecognizer*)sender
 {
-  const auto location = [self getLocationOfPress:sender];
-  const auto child = [self getTouchChild:location];
+  if (sender.state != UIGestureRecognizerStateBegan) {
+    return;
+  }
 
-  if (child) {
-    [child onLongPress];
+  const auto location = [self getLocationOfPress:sender];
+  const auto eventEmitter = [self getTouchEventEmitter:location];
+
+  if (eventEmitter) {
+    const auto eventTarget = eventEmitter->getEventTarget();
+    const auto target = eventTarget ? eventTarget->getTag() : 0;
+    eventEmitter->onLongPress(RNUITextViewChildEventEmitter::OnLongPress{target});
   }
 }
 

--- a/ios/RNUITextViewChild.mm
+++ b/ios/RNUITextViewChild.mm
@@ -5,7 +5,6 @@
 #import <react/renderer/components/RNUITextViewSpec/Props.h>
 #import <react/renderer/components/RNUITextViewSpec/RCTComponentViewHelpers.h>
 #import "RCTFabricComponentsPlugins.h"
-#import "Utils.h"
 
 using namespace facebook::react;
 

--- a/ios/RNUITextViewManager.mm
+++ b/ios/RNUITextViewManager.mm
@@ -1,7 +1,6 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTUIManager.h>
 #import "RCTBridge.h"
-#import "Utils.h"
 
 @interface RNUITextViewManager : RCTViewManager
 @end

--- a/ios/RNUITextViewShadowNode.cpp
+++ b/ios/RNUITextViewShadowNode.cpp
@@ -1,10 +1,20 @@
 #include "RNUITextViewShadowNode.h"
 #include "RNUITextViewChildShadowNode.h"
 #include <react/renderer/components/view/ViewShadowNode.h>
+#include <react/renderer/mounting/ShadowView.h>
 
 #include <cmath>
 
 namespace facebook::react {
+
+static ShadowView shadowViewFromShadowNode(const ShadowNode& shadowNode) {
+  auto shadowView = ShadowView{shadowNode};
+  // The attributed string only needs the component identity and event emitter.
+  // Dropping props and state avoids retaining the shadow tree through state.
+  shadowView.props = nullptr;
+  shadowView.state = nullptr;
+  return shadowView;
+}
 
 RNUITextViewShadowNode::RNUITextViewShadowNode(
    const ShadowNode& sourceShadowNode,
@@ -28,6 +38,25 @@ Size RNUITextViewShadowNode::measureContent(
       paragraphAttributes.ellipsizeMode = EllipsizeMode::Clip;
     }
 
+    const auto attributedString = getAttributedString(layoutContext);
+
+    TextLayoutContext textLayoutContext{
+      .pointScaleFactor = layoutContext.pointScaleFactor,
+      .surfaceId = getSurfaceId(),
+    };
+    const auto textLayoutManager = std::make_shared<const TextLayoutManager>(getContextContainer());
+
+    return textLayoutManager->measure(
+      AttributedStringBox{attributedString},
+      paragraphAttributes,
+      textLayoutContext,
+      layoutConstraints
+    ).size;
+}
+
+AttributedString RNUITextViewShadowNode::getAttributedString(
+  const LayoutContext& layoutContext) const {
+    const auto &baseProps = getConcreteProps();
     auto baseTextAttributes = TextAttributes::defaultTextAttributes();
     baseTextAttributes.backgroundColor = baseProps.backgroundColor;
     baseTextAttributes.allowFontScaling = baseProps.allowFontScaling;
@@ -111,29 +140,19 @@ Size RNUITextViewShadowNode::measureContent(
 
         fragment.string = props.text;
         fragment.textAttributes = textAttributes;
+        fragment.parentShadowView = shadowViewFromShadowNode(*textViewChild);
 
         baseAttributedString.appendFragment(std::move(fragment));
       }
     }
     
-    _attributedString = baseAttributedString;
-    
-    TextLayoutContext textLayoutContext{};
-    textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
-    const auto textLayoutManager = std::make_shared<const TextLayoutManager>(getContextContainer());
-        
-    return textLayoutManager->measure(
-      AttributedStringBox{baseAttributedString},
-      paragraphAttributes,
-      textLayoutContext,
-      layoutConstraints
-    ).size;
+    return baseAttributedString;
 }
 
 void RNUITextViewShadowNode::layout(LayoutContext layoutContext) {
   ensureUnsealed();
   setStateData(RNUITextViewStateReal{
-    _attributedString
+    getAttributedString(layoutContext)
   });
 }
 }

--- a/ios/RNUITextViewShadowNode.h
+++ b/ios/RNUITextViewShadowNode.h
@@ -43,6 +43,6 @@ public:
       const LayoutConstraints& layoutConstraints) const override;
 
 private:
-  mutable AttributedString _attributedString;
+  AttributedString getAttributedString(const LayoutContext& layoutContext) const;
 };
 } // namespace facebook::React

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsky.app/react-native-uitextview",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "UITextView for React Native",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
@@ -82,7 +82,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.80.0"
+    "react-native": ">=0.81.5"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,7 +2830,7 @@ __metadata:
     typescript: ^5.8.3
   peerDependencies:
     react: "*"
-    react-native: ">=0.80.0"
+    react-native: ">=0.81.5"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- route nested text presses and long presses through attributed-string Fabric event emitters
- align UITextView layout and state handling with current React Native, including default tail ellipsis and glyph-aware hit testing
- add a Bluesky-shaped regression fixture and declare React Native 0.81.5+ compatibility

## Testing

- yarn typecheck
- repository pre-commit lint
- iOS example app build and manual verification

Linear: https://linear.app/blueskyweb/issue/APP-2745/new-archios-tapping-a-handle-in-post-anchor-view-doesnt-work