### PR TITLE
Fix onLongPress, add Text-like press feedback to UITextView

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ add to a link.
 </Text>
 ```
 
+Pressable `UITextView` text uses the same rounded gray press highlight as
+React Native `Text`. The highlight appears immediately, remains visible for at
+least 130 ms on a quick tap, and covers non-pressable nested spans belonging to
+the same pressable parent. Set `suppressHighlighting` to disable the visual
+feedback without disabling `onPress` or `onLongPress`.
+
 ## Selection Detection
 
 `UITextView` supports native selection change events via the `onSelectionChange` callback.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -622,26 +622,36 @@ export default function App() {
               style={styles.text}
               selectable
               uiTextView
-              onPress={() => onPress(1)}
-              onLongPress={() => onLongPress(1)}>
+              onPress={() => onPress(1)}>
               Press Me
+            </Text>
+            <Text
+              style={styles.text}
+              selectable
+              suppressHighlighting
+              uiTextView
+              onPress={() => onPress(1)}>
+              Press Me without a highlight
             </Text>
             <Text style={styles.text} selectable uiTextView>
               Portions of UITextView text:{' '}
               <Text
                 style={[styles.text, styles.coloredBlue, styles.underlined]}
-                onPress={() => onPress(1)}>
+                onPress={() => onPress(1)}
+                onLongPress={() => onLongPress(1)}>
                 Part One
               </Text>{' '}
               <Text
                 style={[styles.text, styles.coloredHsl, styles.underlined]}
-                onPress={() => onPress(2)}>
+                onPress={() => onPress(2)}
+                onLongPress={() => onLongPress(2)}>
                 Part Two
               </Text>{' '}
               <Text style={[styles.text]}>Emoji 😅😅😅😅</Text>P
               <Text
                 style={[styles.text, styles.coloredHex, styles.underlined]}
-                onPress={() => onPress(3)}>
+                onPress={() => onPress(3)}
+                onLongPress={() => onLongPress(3)}>
                 Part Three{' '}
               </Text>
             </Text>

--- a/ios/RNUITextView.mm
+++ b/ios/RNUITextView.mm
@@ -10,7 +10,15 @@
 #import <react/renderer/components/RNUITextViewSpec/RCTComponentViewHelpers.h>
 #import "RCTFabricComponentsPlugins.h"
 
+#include <cmath>
+
 using namespace facebook::react;
+
+// Matches Pressability's DEFAULT_MIN_PRESS_DURATION. Without this, a quick tap
+// can add and remove the highlight layer before Core Animation presents it.
+static const CFTimeInterval RNUITextViewMinimumPressHighlightDuration = 0.13;
+static const CFTimeInterval RNUITextViewLongPressDelay = 0.5;
+static const CGFloat RNUITextViewPressMovementThreshold = 10;
 
 static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsizeMode ellipsizeMode)
 {
@@ -26,6 +34,79 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
   }
 }
 
+@interface RNUITextViewPressGestureRecognizer : UIGestureRecognizer
+
+@property (nonatomic, assign) BOOL hasLongPressHandler;
+@property (nonatomic, assign) BOOL exceededLongPressMovement;
+
+@end
+
+
+@implementation RNUITextViewPressGestureRecognizer {
+  CGPoint _initialLocation;
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  if (self.state != UIGestureRecognizerStatePossible || touches.count != 1) {
+    self.state = UIGestureRecognizerStateCancelled;
+    return;
+  }
+
+  _initialLocation = [touches.anyObject locationInView:self.view];
+  self.exceededLongPressMovement = NO;
+  // Unlike UILongPressGestureRecognizer, transition synchronously from the raw
+  // touch instead of waiting for a timer-backed recognition pass.
+  self.state = UIGestureRecognizerStateBegan;
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  const auto location = [touches.anyObject locationInView:self.view];
+  if (std::hypot(location.x - _initialLocation.x, location.y - _initialLocation.y) >
+      RNUITextViewPressMovementThreshold) {
+    // Pressability cancels long-press recognition after 10 points of travel,
+    // but keeps the ordinary press alive while it remains inside the expanded
+    // press-retention rectangle.
+    self.exceededLongPressMovement = YES;
+  }
+  self.state = UIGestureRecognizerStateChanged;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  self.state = UIGestureRecognizerStateEnded;
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  self.state = UIGestureRecognizerStateCancelled;
+}
+
+- (BOOL)canPreventGestureRecognizer:(UIGestureRecognizer *)preventedGestureRecognizer
+{
+  // When this recognizer is active, the touch began on pressable text. In that
+  // case link interaction wins over UITextView's selection recognizers, while
+  // ancestor gestures such as a parent scroll view remain simultaneous.
+  const auto belongsToTextView =
+      preventedGestureRecognizer.view != nil &&
+      [preventedGestureRecognizer.view isDescendantOfView:self.view];
+  return self.hasLongPressHandler && belongsToTextView;
+}
+
+- (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer
+{
+  const auto belongsToTextView =
+      preventingGestureRecognizer.view != nil &&
+      [preventingGestureRecognizer.view isDescendantOfView:self.view];
+  if (belongsToTextView) {
+    return !self.hasLongPressHandler;
+  }
+  return YES;
+}
+
+@end
+
 @interface RNUITextView () <RCTRNUITextViewViewProtocol, UIGestureRecognizerDelegate, UITextViewDelegate>
 
 @end
@@ -35,6 +116,24 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
   UITextView * _textView;
   RNUITextViewShadowNode::ConcreteState::Shared _state;
   UITapGestureRecognizer * _outsideTapRecognizer;
+  RNUITextViewPressGestureRecognizer * _pressGestureRecognizer;
+  CAShapeLayer * _highlightLayer;
+  NSString * _activeHighlightGroup;
+  NSString * _activePressGroup;
+  std::shared_ptr<const RNUITextViewChildEventEmitter> _activePressEventEmitter;
+  BOOL _pressIsActive;
+  BOOL _pressIsWithinRetention;
+  BOOL _longPressIsEligible;
+  BOOL _activePressSuppressesHighlighting;
+  BOOL _longPressDispatched;
+  BOOL _activePressHasPressHandler;
+  BOOL _activePressHasLongPressHandler;
+  NSUInteger _pressGeneration;
+  CFTimeInterval _pressActivationTime;
+  CGRect _activePressRect;
+  UIEdgeInsets _activePressRetentionOffset;
+  CFTimeInterval _highlightActivationTime;
+  NSUInteger _highlightGeneration;
   BOOL _suppressSelectionChange;
 }
 
@@ -53,7 +152,14 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
     self.contentView = _view;
     self.clipsToBounds = true;
 
-    _textView = [[UITextView alloc] init];
+    if (@available(iOS 16.0, *)) {
+      // This component relies on NSLayoutManager for measurement, hit-testing,
+      // and press-highlight geometry. Opt into TextKit 1 up front instead of
+      // making UITextView create TextKit 2 and fall back on first access.
+      _textView = [UITextView textViewUsingTextLayoutManager:NO];
+    } else {
+      _textView = [[UITextView alloc] init];
+    }
     _textView.scrollEnabled = false;
     _textView.editable = false;
     _textView.selectable = false;
@@ -68,17 +174,11 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
     _textView.layoutManager.usesFontLeading = NO;
     [self addSubview:_textView];
 
-    const auto longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
-                                                                                          action:@selector(handleLongPressIfNecessary:)];
-    longPressGestureRecognizer.delegate = self;
-
-    const auto pressGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
-                                                                                action:@selector(handlePressIfNecessary:)];
-    pressGestureRecognizer.delegate = self;
-    [pressGestureRecognizer requireGestureRecognizerToFail:longPressGestureRecognizer];
-
-    [_textView addGestureRecognizer:pressGestureRecognizer];
-    [_textView addGestureRecognizer:longPressGestureRecognizer];
+    _pressGestureRecognizer = [[RNUITextViewPressGestureRecognizer alloc] initWithTarget:self
+                                                                                  action:@selector(handlePressGesture:)];
+    _pressGestureRecognizer.cancelsTouchesInView = NO;
+    _pressGestureRecognizer.delegate = self;
+    [_textView addGestureRecognizer:_pressGestureRecognizer];
 
     _outsideTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                     action:@selector(handleOutsideTap:)];
@@ -95,6 +195,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
   if (self.window) {
     [self.window addGestureRecognizer:_outsideTapRecognizer];
   } else {
+    [self invalidateActivePress];
+    [self clearPressHighlight];
     [_outsideTapRecognizer.view removeGestureRecognizer:_outsideTapRecognizer];
   }
 }
@@ -108,6 +210,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
 - (void)prepareForRecycle
 {
   [super prepareForRecycle];
+  [self invalidateActivePress];
+  [self clearPressHighlight];
   _state.reset();
 
   // Reset the frame to zero so that when it properly lays out on the next use
@@ -162,6 +266,10 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
   }
   if (frameChanged) {
     _textView.frame = _view.frame;
+  }
+
+  if (_activeHighlightGroup != nil) {
+    [self updatePressHighlight];
   }
 
   __block std::vector<std::string> lines;
@@ -234,6 +342,17 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
+  if (gestureRecognizer == _pressGestureRecognizer || otherGestureRecognizer == _pressGestureRecognizer) {
+    const auto companion = gestureRecognizer == _pressGestureRecognizer
+        ? otherGestureRecognizer
+        : gestureRecognizer;
+    const auto belongsToTextView =
+        companion.view != nil && [companion.view isDescendantOfView:_textView];
+    // Press-only spans coexist with UITextView's recognizers; an actual
+    // selection invalidates the press in textViewDidChangeSelection:. Links
+    // with onLongPress own the hold, while ancestor scrolling can cancel both.
+    return belongsToTextView && !_pressGestureRecognizer.hasLongPressHandler;
+  }
   return YES;
 }
 
@@ -246,6 +365,24 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
     }
     UIView *hitView = [window hitTest:[touch locationInView:nil] withEvent:nil];
     return ![hitView isDescendantOfView:self];
+  }
+  if (gestureRecognizer == _pressGestureRecognizer) {
+    const auto location = [touch locationInView:_textView];
+    const auto eventEmitter = [self getTouchEventEmitter:location];
+    BOOL hasLongPressHandler = NO;
+    const auto group = [self highlightGroupForEventEmitter:eventEmitter
+                                       suppressHighlighting:nullptr
+                                            hasPressHandler:nullptr
+                                        hasLongPressHandler:&hasLongPressHandler
+                                       pressRetentionOffset:nullptr];
+    _pressGestureRecognizer.hasLongPressHandler = hasLongPressHandler;
+    // The recognizer enters `Began` synchronously. For a span that owns a
+    // long press, cancel delivery of that same touch to UITextView so its
+    // selection interaction cannot start in parallel. Keep this disabled for
+    // press-only spans: a hold on those should still be available to native
+    // text selection.
+    _pressGestureRecognizer.cancelsTouchesInView = hasLongPressHandler;
+    return group != nil;
   }
   return YES;
 }
@@ -264,6 +401,343 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
 }
 
 // MARK: - Touch handling
+
+- (NSString *)highlightGroupForEventEmitter:(std::shared_ptr<const RNUITextViewChildEventEmitter>)eventEmitter
+                       suppressHighlighting:(BOOL *)suppressHighlighting
+                            hasPressHandler:(BOOL *)hasPressHandler
+                        hasLongPressHandler:(BOOL *)hasLongPressHandler
+                       pressRetentionOffset:(UIEdgeInsets *)pressRetentionOffset
+{
+  if (!_state || !eventEmitter) {
+    return nil;
+  }
+
+  const auto eventTarget = eventEmitter->getEventTarget();
+  if (!eventTarget) {
+    return nil;
+  }
+
+  const auto tag = eventTarget->getTag();
+  for (const auto &metadata : _state->getData().highlightMetadata) {
+    if (metadata.tag == tag) {
+      const auto separator = metadata.group.rfind('|');
+      const auto handlers = separator == std::string::npos
+          ? std::string{}
+          : metadata.group.substr(separator + 1);
+      if (suppressHighlighting != nullptr) {
+        *suppressHighlighting = metadata.suppressHighlighting;
+      }
+      if (hasPressHandler != nullptr) {
+        *hasPressHandler = handlers.find('p') != std::string::npos;
+      }
+      if (hasLongPressHandler != nullptr) {
+        *hasLongPressHandler = handlers.find('l') != std::string::npos;
+      }
+      if (pressRetentionOffset != nullptr) {
+        *pressRetentionOffset = UIEdgeInsetsMake(
+            metadata.pressRetentionOffsetTop,
+            metadata.pressRetentionOffsetLeft,
+            metadata.pressRetentionOffsetBottom,
+            metadata.pressRetentionOffsetRight);
+      }
+      return [NSString stringWithUTF8String:metadata.group.c_str()];
+    }
+  }
+
+  return nil;
+}
+
+- (CGRect)textRectForHighlightGroup:(NSString *)highlightGroup
+{
+  __block CGRect textRect = CGRectNull;
+  const auto fullRange = NSMakeRange(0, _textView.attributedText.length);
+  [_textView.attributedText enumerateAttribute:RCTAttributedStringEventEmitterKey
+                                       inRange:fullRange
+                                       options:0
+                                    usingBlock:^(NSData *eventEmitterWrapper, NSRange characterRange, BOOL *stop) {
+    if (eventEmitterWrapper == nil) {
+      return;
+    }
+
+    const auto eventEmitter = std::dynamic_pointer_cast<const RNUITextViewChildEventEmitter>(
+        RCTUnwrapEventEmitter(eventEmitterWrapper));
+    const auto group = [self highlightGroupForEventEmitter:eventEmitter
+                                      suppressHighlighting:nullptr
+                                           hasPressHandler:nullptr
+                                       hasLongPressHandler:nullptr
+                                      pressRetentionOffset:nullptr];
+    if (![group isEqualToString:highlightGroup]) {
+      return;
+    }
+
+    const auto glyphRange = [self->_textView.layoutManager glyphRangeForCharacterRange:characterRange
+                                                                  actualCharacterRange:nullptr];
+    [self->_textView.layoutManager enumerateEnclosingRectsForGlyphRange:glyphRange
+                                                withinSelectedGlyphRange:glyphRange
+                                                         inTextContainer:self->_textView.textContainer
+                                                              usingBlock:^(CGRect enclosingRect, BOOL *anotherStop) {
+      const auto inset = self->_textView.textContainerInset;
+      const auto rect = CGRectOffset(enclosingRect, inset.left, inset.top);
+      textRect = CGRectIsNull(textRect) ? rect : CGRectUnion(textRect, rect);
+    }];
+  }];
+  return textRect;
+}
+
+- (BOOL)isLocationWithinActivePressRect:(CGPoint)location
+{
+  if (CGRectIsNull(_activePressRect)) {
+    return NO;
+  }
+
+  const auto offset = _activePressRetentionOffset;
+  const auto retainedRect = CGRectMake(
+      CGRectGetMinX(_activePressRect) - offset.left,
+      CGRectGetMinY(_activePressRect) - offset.top,
+      CGRectGetWidth(_activePressRect) + offset.left + offset.right,
+      CGRectGetHeight(_activePressRect) + offset.top + offset.bottom);
+  return CGRectContainsPoint(retainedRect, location);
+}
+
+- (void)clearPressHighlight
+{
+  _highlightGeneration++;
+  _activeHighlightGroup = nil;
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  [_highlightLayer removeFromSuperlayer];
+  [CATransaction commit];
+  _highlightLayer = nil;
+}
+
+- (void)activatePressHighlight
+{
+  _highlightGeneration++;
+  _activeHighlightGroup = _activePressGroup;
+  _highlightActivationTime = CACurrentMediaTime();
+  [self updatePressHighlight];
+}
+
+- (void)invalidateActivePress
+{
+  _pressGeneration++;
+  _pressIsActive = NO;
+  _pressIsWithinRetention = NO;
+  _longPressIsEligible = NO;
+  _activePressSuppressesHighlighting = NO;
+  _longPressDispatched = NO;
+  _activePressHasPressHandler = NO;
+  _activePressHasLongPressHandler = NO;
+  _activePressRect = CGRectNull;
+  _activePressGroup = nil;
+  _activePressEventEmitter.reset();
+}
+
+- (void)emitPressEvent:(BOOL)isLongPress
+           eventEmitter:(std::shared_ptr<const RNUITextViewChildEventEmitter>)eventEmitter
+{
+  if (!eventEmitter) {
+    return;
+  }
+
+  const auto eventTarget = eventEmitter->getEventTarget();
+  const auto target = eventTarget ? eventTarget->getTag() : 0;
+  if (isLongPress) {
+    eventEmitter->onLongPress(RNUITextViewChildEventEmitter::OnLongPress{target});
+  } else {
+    eventEmitter->onPress(RNUITextViewChildEventEmitter::OnPress{target});
+  }
+}
+
+- (void)emitLongPressIfNecessary
+{
+  if (!_pressIsActive || !_pressIsWithinRetention || !_longPressIsEligible ||
+      _longPressDispatched || !_activePressHasLongPressHandler) {
+    return;
+  }
+
+  // Set this before emitting so a synchronous update cannot make release fall
+  // through to onPress while the long-press event is being dispatched.
+  _longPressDispatched = YES;
+  [self emitPressEvent:YES eventEmitter:_activePressEventEmitter];
+}
+
+- (void)clearPressHighlightAfterMinimumDuration
+{
+  if (_activeHighlightGroup == nil) {
+    return;
+  }
+
+  const auto elapsed = CACurrentMediaTime() - _highlightActivationTime;
+  const auto remaining = RNUITextViewMinimumPressHighlightDuration - elapsed;
+  if (remaining <= 0) {
+    [self clearPressHighlight];
+    return;
+  }
+
+  const auto generation = ++_highlightGeneration;
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(remaining * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+    if (self->_highlightGeneration == generation) {
+      [self clearPressHighlight];
+    }
+  });
+}
+
+- (void)updatePressHighlight
+{
+  if (_activeHighlightGroup == nil || _textView.attributedText.length == 0) {
+    [self clearPressHighlight];
+    return;
+  }
+
+  __block UIBezierPath *highlightPath = nil;
+  const auto fullRange = NSMakeRange(0, _textView.attributedText.length);
+  [_textView.attributedText enumerateAttribute:RCTAttributedStringEventEmitterKey
+                                       inRange:fullRange
+                                       options:0
+                                    usingBlock:^(NSData *eventEmitterWrapper, NSRange characterRange, BOOL *stop) {
+    if (eventEmitterWrapper == nil) {
+      return;
+    }
+
+    const auto eventEmitter = std::dynamic_pointer_cast<const RNUITextViewChildEventEmitter>(
+        RCTUnwrapEventEmitter(eventEmitterWrapper));
+    const auto group = [self highlightGroupForEventEmitter:eventEmitter
+                                      suppressHighlighting:nullptr
+                                           hasPressHandler:nullptr
+                                       hasLongPressHandler:nullptr
+                                      pressRetentionOffset:nullptr];
+    if (![group isEqualToString:self->_activeHighlightGroup]) {
+      return;
+    }
+
+    const auto glyphRange = [self->_textView.layoutManager glyphRangeForCharacterRange:characterRange
+                                                                  actualCharacterRange:nullptr];
+    [self->_textView.layoutManager enumerateEnclosingRectsForGlyphRange:glyphRange
+                                                withinSelectedGlyphRange:glyphRange
+                                                         inTextContainer:self->_textView.textContainer
+                                                              usingBlock:^(CGRect enclosingRect, BOOL *anotherStop) {
+      const auto inset = self->_textView.textContainerInset;
+      const auto textViewRect = CGRectOffset(enclosingRect, inset.left, inset.top);
+      const auto path = [UIBezierPath bezierPathWithRoundedRect:CGRectInset(textViewRect, -2, -2)
+                                                   cornerRadius:2];
+      if (highlightPath != nil) {
+        [highlightPath appendPath:path];
+      } else {
+        highlightPath = path;
+      }
+    }];
+  }];
+
+  if (highlightPath == nil) {
+    [self clearPressHighlight];
+    return;
+  }
+
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  if (_highlightLayer == nil) {
+    _highlightLayer = [CAShapeLayer layer];
+    _highlightLayer.fillColor = [UIColor colorWithWhite:0 alpha:0.25].CGColor;
+    [_textView.layer addSublayer:_highlightLayer];
+  }
+  _highlightLayer.frame = _textView.bounds;
+  _highlightLayer.path = highlightPath.CGPath;
+  [CATransaction commit];
+}
+
+- (void)handlePressGesture:(RNUITextViewPressGestureRecognizer *)sender
+{
+  if (sender.state == UIGestureRecognizerStateBegan) {
+    [self invalidateActivePress];
+    [self clearPressHighlight];
+
+    const auto location = [self getLocationOfPress:sender];
+    const auto eventEmitter = [self getTouchEventEmitter:location];
+    BOOL suppressHighlighting = NO;
+    BOOL hasPressHandler = NO;
+    UIEdgeInsets pressRetentionOffset = UIEdgeInsetsZero;
+    const auto group = [self highlightGroupForEventEmitter:eventEmitter
+                                      suppressHighlighting:&suppressHighlighting
+                                           hasPressHandler:&hasPressHandler
+                                       hasLongPressHandler:nullptr
+                                      pressRetentionOffset:&pressRetentionOffset];
+    if (group == nil) {
+      return;
+    }
+
+    _pressIsActive = YES;
+    _pressIsWithinRetention = YES;
+    _activePressGroup = group;
+    _activePressEventEmitter = eventEmitter;
+    _activePressHasPressHandler = hasPressHandler;
+    _activePressHasLongPressHandler = sender.hasLongPressHandler;
+    _longPressIsEligible = _activePressHasLongPressHandler;
+    _activePressSuppressesHighlighting = suppressHighlighting;
+    _activePressRect = [self textRectForHighlightGroup:group];
+    _activePressRetentionOffset = pressRetentionOffset;
+    _pressActivationTime = CACurrentMediaTime();
+
+    if (!_activePressSuppressesHighlighting) {
+      [self activatePressHighlight];
+    }
+
+    if (_activePressHasLongPressHandler) {
+      const auto generation = _pressGeneration;
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(RNUITextViewLongPressDelay * NSEC_PER_SEC)),
+                     dispatch_get_main_queue(), ^{
+        if (self->_pressGeneration == generation) {
+          [self emitLongPressIfNecessary];
+        }
+      });
+    }
+    return;
+  }
+
+  if (sender.state == UIGestureRecognizerStateChanged && _pressIsActive) {
+    const auto location = [self getLocationOfPress:sender];
+    const auto isWithinRetention = [self isLocationWithinActivePressRect:location];
+    if (sender.exceededLongPressMovement || !isWithinRetention) {
+      _longPressIsEligible = NO;
+    }
+    if (_pressIsWithinRetention && !isWithinRetention) {
+      _pressIsWithinRetention = NO;
+      [self clearPressHighlightAfterMinimumDuration];
+    } else if (!_pressIsWithinRetention && isWithinRetention) {
+      _pressIsWithinRetention = YES;
+      if (!_activePressSuppressesHighlighting) {
+        [self activatePressHighlight];
+      }
+    }
+    return;
+  }
+
+  if (sender.state == UIGestureRecognizerStateEnded) {
+    _pressIsWithinRetention =
+        _pressIsActive && [self isLocationWithinActivePressRect:[self getLocationOfPress:sender]];
+    if (_pressIsActive && _pressIsWithinRetention && !_longPressDispatched &&
+        _longPressIsEligible && _activePressHasLongPressHandler &&
+        CACurrentMediaTime() - _pressActivationTime >= RNUITextViewLongPressDelay) {
+      // The finger can lift after the threshold but before the main-queue timer
+      // gets serviced. Treat elapsed time as authoritative in that race.
+      [self emitLongPressIfNecessary];
+    }
+    if (_pressIsActive && _pressIsWithinRetention && !_longPressDispatched &&
+        _activePressHasPressHandler) {
+      [self emitPressEvent:NO eventEmitter:_activePressEventEmitter];
+    }
+    [self invalidateActivePress];
+    [self clearPressHighlightAfterMinimumDuration];
+    return;
+  }
+
+  if (sender.state == UIGestureRecognizerStateCancelled ||
+      sender.state == UIGestureRecognizerStateFailed) {
+    [self invalidateActivePress];
+    [self clearPressHighlightAfterMinimumDuration];
+  }
+}
 
 - (CGPoint)getLocationOfPress:(UIGestureRecognizer*)sender
 {
@@ -307,34 +781,6 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
   return std::dynamic_pointer_cast<const RNUITextViewChildEventEmitter>(eventEmitter);
 }
 
-- (void)handlePressIfNecessary:(UITapGestureRecognizer*)sender
-{
-  const auto location = [self getLocationOfPress:sender];
-  const auto eventEmitter = [self getTouchEventEmitter:location];
-
-  if (eventEmitter) {
-    const auto eventTarget = eventEmitter->getEventTarget();
-    const auto target = eventTarget ? eventTarget->getTag() : 0;
-    eventEmitter->onPress(RNUITextViewChildEventEmitter::OnPress{target});
-  }
-}
-
-- (void)handleLongPressIfNecessary:(UILongPressGestureRecognizer*)sender
-{
-  if (sender.state != UIGestureRecognizerStateBegan) {
-    return;
-  }
-
-  const auto location = [self getLocationOfPress:sender];
-  const auto eventEmitter = [self getTouchEventEmitter:location];
-
-  if (eventEmitter) {
-    const auto eventTarget = eventEmitter->getEventTarget();
-    const auto target = eventTarget ? eventTarget->getTag() : 0;
-    eventEmitter->onLongPress(RNUITextViewChildEventEmitter::OnLongPress{target});
-  }
-}
-
 // MARK: - UITextViewDelegate
 
 - (void)textViewDidChangeSelection:(UITextView *)textView
@@ -342,11 +788,27 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(RNUITextViewEllipsize
   if (_suppressSelectionChange) {
     return;
   }
+
+  const NSRange selectedRange = textView.selectedRange;
+  if (_pressIsActive && selectedRange.location != NSNotFound && selectedRange.length > 0) {
+    if (_activePressHasLongPressHandler) {
+      // A link with onLongPress owns the hold. Undo any selection started by
+      // UITextView without cancelling the link's pending long-press timer.
+      _suppressSelectionChange = YES;
+      textView.selectedTextRange = nil;
+      _suppressSelectionChange = NO;
+      return;
+    }
+
+    // Without onLongPress, native selection owns the hold and the pending tap
+    // must not fire when the finger eventually lifts.
+    [self invalidateActivePress];
+    [self clearPressHighlightAfterMinimumDuration];
+  }
   if (_eventEmitter == nullptr) {
     return;
   }
 
-  const NSRange selectedRange = textView.selectedRange;
   if (selectedRange.location == NSNotFound) {
     return;
   }

--- a/ios/RNUITextViewShadowNode.cpp
+++ b/ios/RNUITextViewShadowNode.cpp
@@ -55,7 +55,8 @@ Size RNUITextViewShadowNode::measureContent(
 }
 
 AttributedString RNUITextViewShadowNode::getAttributedString(
-  const LayoutContext& layoutContext) const {
+  const LayoutContext& layoutContext,
+  std::vector<RNUITextViewHighlightMetadata> *highlightMetadata) const {
     const auto &baseProps = getConcreteProps();
     auto baseTextAttributes = TextAttributes::defaultTextAttributes();
     baseTextAttributes.backgroundColor = baseProps.backgroundColor;
@@ -142,6 +143,18 @@ AttributedString RNUITextViewShadowNode::getAttributedString(
         fragment.textAttributes = textAttributes;
         fragment.parentShadowView = shadowViewFromShadowNode(*textViewChild);
 
+        if (highlightMetadata != nullptr && !props.highlightGroup.empty()) {
+          highlightMetadata->push_back(RNUITextViewHighlightMetadata{
+            fragment.parentShadowView.tag,
+            props.highlightGroup,
+            props.suppressHighlighting,
+            props.pressRetentionOffsetTop,
+            props.pressRetentionOffsetRight,
+            props.pressRetentionOffsetBottom,
+            props.pressRetentionOffsetLeft,
+          });
+        }
+
         baseAttributedString.appendFragment(std::move(fragment));
       }
     }
@@ -151,8 +164,10 @@ AttributedString RNUITextViewShadowNode::getAttributedString(
 
 void RNUITextViewShadowNode::layout(LayoutContext layoutContext) {
   ensureUnsealed();
+  auto highlightMetadata = std::vector<RNUITextViewHighlightMetadata>{};
   setStateData(RNUITextViewStateReal{
-    getAttributedString(layoutContext)
+    getAttributedString(layoutContext, &highlightMetadata),
+    std::move(highlightMetadata),
   });
 }
 }

--- a/ios/RNUITextViewShadowNode.h
+++ b/ios/RNUITextViewShadowNode.h
@@ -7,13 +7,27 @@
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/ShadowNode.h>
 
+#include <string>
+#include <vector>
+
 namespace facebook::react {
 
 extern const char RNUITextViewComponentName[];
 
+struct RNUITextViewHighlightMetadata {
+  Tag tag;
+  std::string group;
+  bool suppressHighlighting;
+  Float pressRetentionOffsetTop;
+  Float pressRetentionOffsetRight;
+  Float pressRetentionOffsetBottom;
+  Float pressRetentionOffsetLeft;
+};
+
 class RNUITextViewStateReal final {
  public:
   AttributedString attributedString;
+  std::vector<RNUITextViewHighlightMetadata> highlightMetadata;
 };
 
 class RNUITextViewShadowNode final : public ConcreteViewShadowNode<
@@ -43,6 +57,8 @@ public:
       const LayoutConstraints& layoutConstraints) const override;
 
 private:
-  AttributedString getAttributedString(const LayoutContext& layoutContext) const;
+  AttributedString getAttributedString(
+      const LayoutContext& layoutContext,
+      std::vector<RNUITextViewHighlightMetadata> *highlightMetadata = nullptr) const;
 };
 } // namespace facebook::React

--- a/src/RNUITextViewChildNativeComponent.ts
+++ b/src/RNUITextViewChildNativeComponent.ts
@@ -40,6 +40,15 @@ interface NativeProps extends ViewProps {
   textDecorationColor?: ColorValue
   textAlign?: CodegenTypes.WithDefault<TextAlign, 'auto'>
   shadowRadius?: CodegenTypes.WithDefault<CodegenTypes.Float, 0>
+  /** Internal identifier used to highlight all fragments in a pressable Text. */
+  highlightGroup?: string
+  /** Internal copy of Text's suppressHighlighting prop. */
+  suppressHighlighting?: boolean
+  /** Internal expansion of the owning Text's press-retention rectangle. */
+  pressRetentionOffsetTop?: CodegenTypes.WithDefault<CodegenTypes.Float, 20>
+  pressRetentionOffsetRight?: CodegenTypes.WithDefault<CodegenTypes.Float, 20>
+  pressRetentionOffsetBottom?: CodegenTypes.WithDefault<CodegenTypes.Float, 30>
+  pressRetentionOffsetLeft?: CodegenTypes.WithDefault<CodegenTypes.Float, 20>
   onPress?: CodegenTypes.BubblingEventHandler<TargetedEvent>
   onLongPress?: CodegenTypes.BubblingEventHandler<TargetedEvent>
 }

--- a/src/Text.tsx
+++ b/src/Text.tsx
@@ -8,12 +8,18 @@ import {
 } from 'react-native'
 import RNUITextViewChildNativeComponent from './RNUITextViewChildNativeComponent'
 import RNUITextViewNativeComponent from './RNUITextViewNativeComponent'
+import {resolvePressContext, type PressContext} from './press'
 import {flattenStyles} from './util'
 
-const TextAncestorContext = React.createContext<[boolean, ViewStyle]>([
-  false,
-  StyleSheet.create({}),
-])
+type TextAncestorContextValue = PressContext & {
+  isAncestor: boolean
+  rootStyle: ViewStyle
+}
+
+const TextAncestorContext = React.createContext<TextAncestorContextValue>({
+  isAncestor: false,
+  rootStyle: StyleSheet.create({}),
+})
 
 const textDefaults: TextProps = {
   allowFontScaling: true,
@@ -42,7 +48,38 @@ type UITextViewProps = TextProps & {
 }
 
 function UITextViewChild({style, children, ...rest}: UITextViewProps) {
-  const [isAncestor, rootStyle] = useTextAncestorContext()
+  const {
+    isAncestor,
+    rootStyle,
+    highlightGroup: ancestorHighlightGroup,
+    suppressHighlighting: ancestorSuppressHighlighting,
+    pressRetentionOffset: ancestorPressRetentionOffset,
+    onPress: ancestorOnPress,
+    onLongPress: ancestorOnLongPress,
+  } = useTextAncestorContext()
+  const ownHighlightGroup = React.useId()
+  const {
+    highlightGroup,
+    suppressHighlighting,
+    pressRetentionOffset,
+    onPress,
+    onLongPress,
+  } = resolvePressContext(ownHighlightGroup, rest, {
+    highlightGroup: ancestorHighlightGroup,
+    suppressHighlighting: ancestorSuppressHighlighting,
+    pressRetentionOffset: ancestorPressRetentionOffset,
+    onPress: ancestorOnPress,
+    onLongPress: ancestorOnLongPress,
+  })
+  // The native event currently contains only `target`, while TextProps types
+  // these callbacks as full gesture events. Preserve the existing public type
+  // and adapt it only at the private Codegen boundary.
+  const nativeOnPress = onPress as React.ComponentProps<
+    typeof RNUITextViewChildNativeComponent
+  >['onPress']
+  const nativeOnLongPress = onLongPress as React.ComponentProps<
+    typeof RNUITextViewChildNativeComponent
+  >['onLongPress']
 
   // Flatten the styles, and apply the root styles when needed
   const flattenedStyle = React.useMemo(
@@ -52,7 +89,16 @@ function UITextViewChild({style, children, ...rest}: UITextViewProps) {
 
   if (!isAncestor) {
     return (
-      <TextAncestorContext.Provider value={[true, flattenedStyle]}>
+      <TextAncestorContext.Provider
+        value={{
+          isAncestor: true,
+          rootStyle: flattenedStyle,
+          highlightGroup,
+          suppressHighlighting,
+          pressRetentionOffset,
+          onPress,
+          onLongPress,
+        }}>
         <RNUITextViewNativeComponent
           {...textDefaults}
           {...rest}
@@ -66,12 +112,19 @@ function UITextViewChild({style, children, ...rest}: UITextViewProps) {
               return c
             } else if (typeof c === 'string' || typeof c === 'number') {
               return (
-                // @ts-expect-error @TODO fix this type
                 <RNUITextViewChildNativeComponent
                   key={index}
                   style={flattenedStyle}
                   text={c.toString()}
                   {...rest}
+                  highlightGroup={highlightGroup}
+                  suppressHighlighting={suppressHighlighting}
+                  pressRetentionOffsetTop={pressRetentionOffset?.top}
+                  pressRetentionOffsetRight={pressRetentionOffset?.right}
+                  pressRetentionOffsetBottom={pressRetentionOffset?.bottom}
+                  pressRetentionOffsetLeft={pressRetentionOffset?.left}
+                  onPress={nativeOnPress}
+                  onLongPress={nativeOnLongPress}
                 />
               )
             }
@@ -82,31 +135,47 @@ function UITextViewChild({style, children, ...rest}: UITextViewProps) {
     )
   } else {
     return (
-      <>
+      <TextAncestorContext.Provider
+        value={{
+          isAncestor: true,
+          rootStyle: flattenedStyle,
+          highlightGroup,
+          suppressHighlighting,
+          pressRetentionOffset,
+          onPress,
+          onLongPress,
+        }}>
         {React.Children.toArray(children).map((c, index) => {
           if (React.isValidElement(c)) {
             return c
           } else if (typeof c === 'string' || typeof c === 'number') {
             return (
-              // @ts-expect-error @TODO fix this type
               <RNUITextViewChildNativeComponent
                 key={index}
                 style={flattenedStyle}
                 text={c.toString()}
                 {...rest}
+                highlightGroup={highlightGroup}
+                suppressHighlighting={suppressHighlighting}
+                pressRetentionOffsetTop={pressRetentionOffset?.top}
+                pressRetentionOffsetRight={pressRetentionOffset?.right}
+                pressRetentionOffsetBottom={pressRetentionOffset?.bottom}
+                pressRetentionOffsetLeft={pressRetentionOffset?.left}
+                onPress={nativeOnPress}
+                onLongPress={nativeOnLongPress}
               />
             )
           }
 
           return null
         })}
-      </>
+      </TextAncestorContext.Provider>
     )
   }
 }
 
 function UITextViewInner(props: UITextViewProps) {
-  const [isAncestor] = useTextAncestorContext()
+  const {isAncestor} = useTextAncestorContext()
 
   // Even if the uiTextView prop is set, we can still default to using
   // normal selection (i.e. base RN text) if the text doesn't need to be

--- a/src/__tests__/press.test.ts
+++ b/src/__tests__/press.test.ts
@@ -1,0 +1,62 @@
+import {resolvePressContext} from '../press'
+
+it('creates a new group for pressable text', () => {
+  const onPress = jest.fn()
+  const result = resolvePressContext(
+    'child',
+    {onPress, suppressHighlighting: true},
+    {highlightGroup: 'parent', onLongPress: jest.fn()},
+  )
+
+  expect(result).toEqual({
+    highlightGroup: 'child|p',
+    suppressHighlighting: true,
+    pressRetentionOffset: undefined,
+    onPress,
+    onLongPress: undefined,
+  })
+})
+
+it('inherits the owner through non-pressable nested text', () => {
+  const ancestor = {
+    highlightGroup: 'parent',
+    suppressHighlighting: false,
+    pressRetentionOffset: {top: 1, right: 2, bottom: 3, left: 4},
+    onPress: jest.fn(),
+    onLongPress: jest.fn(),
+  }
+
+  expect(resolvePressContext('child', {}, ancestor)).toBe(ancestor)
+})
+
+it('treats a long-press-only child as its own pressable group', () => {
+  const onLongPress = jest.fn()
+  expect(
+    resolvePressContext(
+      'child',
+      {onLongPress},
+      {highlightGroup: 'parent', onPress: jest.fn()},
+    ),
+  ).toEqual({
+    highlightGroup: 'child|l',
+    suppressHighlighting: false,
+    pressRetentionOffset: undefined,
+    onPress: undefined,
+    onLongPress,
+  })
+})
+
+it('uses the pressable owner retention offset', () => {
+  const pressRetentionOffset = {top: 10, right: 20, bottom: 30, left: 40}
+
+  expect(
+    resolvePressContext(
+      'child',
+      {onPress: jest.fn(), pressRetentionOffset},
+      {
+        highlightGroup: 'parent',
+        pressRetentionOffset: {top: 1, right: 2, bottom: 3, left: 4},
+      },
+    ).pressRetentionOffset,
+  ).toBe(pressRetentionOffset)
+})

--- a/src/press.ts
+++ b/src/press.ts
@@ -1,0 +1,36 @@
+import type {TextProps} from 'react-native'
+
+export type PressContext = {
+  highlightGroup?: string
+  suppressHighlighting?: boolean
+  pressRetentionOffset?: TextProps['pressRetentionOffset']
+  onPress?: TextProps['onPress']
+  onLongPress?: TextProps['onLongPress']
+}
+
+export function resolvePressContext(
+  ownHighlightGroup: string,
+  props: Pick<
+    TextProps,
+    'onPress' | 'onLongPress' | 'pressRetentionOffset' | 'suppressHighlighting'
+  >,
+  ancestor: PressContext,
+): PressContext {
+  const isPressable = props.onPress != null || props.onLongPress != null
+  if (!isPressable) {
+    return ancestor
+  }
+
+  return {
+    // Keep handler capabilities in the identifier that native already uses to
+    // group highlighted fragments. This avoids a separate prop/state channel
+    // getting out of sync with the group and its event emitter.
+    highlightGroup: `${ownHighlightGroup}|${props.onPress ? 'p' : ''}${
+      props.onLongPress ? 'l' : ''
+    }`,
+    suppressHighlighting: props.suppressHighlighting === true,
+    pressRetentionOffset: props.pressRetentionOffset,
+    onPress: props.onPress,
+    onLongPress: props.onLongPress,
+  }
+}


### PR DESCRIPTION
## Summary

- add immediate React Native Text-style press highlighting, including nested press groups and suppressHighlighting
- support onPress/onLongPress arbitration while preserving native selection for press-only text
- match Pressability retention, movement, minimum-highlight, and scroll-cancellation behavior
- initialize UITextView directly in TextKit 1 mode to avoid compatibility warnings
- add press-context tests, documentation, and mirrored example fixtures

## Testing

- yarn prepare
- yarn test --runInBand --no-watchman
- yarn typecheck
- yarn lint
- git diff --check
- adversarial cross-model roast, followed by a clean focused pass

No additional iOS build was run after the final review changes, per request.